### PR TITLE
nim 1.6.0をサポートするためにinputマクロを修正

### DIFF
--- a/nim/utils/base.nim
+++ b/nim/utils/base.nim
@@ -86,9 +86,9 @@ when not declared(INCLUDE_GUARD_UTILS_BASE_NIM):
     result.add quote do: (let `t` = stdin.readLine.split)
     var p : NimNode
     if ty.kind == nnkPar:
-      p := nnkPar.newTree()
+      p = nnkPar.newTree()
     elif ty.kind == nnkTupleConstr:
-      p := nnkTupleConstr.newTree()
+      p = nnkTupleConstr.newTree()
     for i, typ_tmp in ty.pairs:
       var ece, typ: NimNode
       if typ_tmp.kind == nnkExprColonExpr:


### PR DESCRIPTION
1.6.0から、タプルは`nnkPar`ではなく`nnkTupleConstr`でノードが表現されるようになりました。

> Tuple expressions are now parsed consistently as nnkTupleConstr node. Will affect macros expecting nodes to be of nnkPar.
https://github.com/nim-lang/Nim/blob/version-1-6/changelogs/changelog_1_6_0.md

競プロする上でinputマクロにお世話になっているので、今後のversion upでも動くようにPRあげてみました。